### PR TITLE
Mark all outputs as host_dirty, even in pipelines where the target do…

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -294,6 +294,13 @@ Module lower(const vector<Function> &output_funcs,
         s = select_gpu_api(s, t);
         debug(2) << "Lowering after selecting a GPU API for extern stages:\n"
                  << s << "\n\n";
+    } else {
+        // Always mark buffers host dirty. Buffers will otherwise not be correctly copied for
+        // other pipelines with device feature enabled.
+        debug(1) << "Injecting host <-> dev buffer copies...\n";
+        s = inject_host_dev_buffer_copies(s, t);
+        debug(2) << "Lowering after injecting host <-> dev buffer copies:\n"
+                    << s << "\n\n";
     }
 
     if (t.has_feature(Target::OpenGL)) {


### PR DESCRIPTION
…esn't contain a GPU feature.